### PR TITLE
🐛 Fix: 그룹 생성 시 학생은 생성하지 못하도록 수정

### DIFF
--- a/moongge/src/main/java/com/narsha/moongge/base/code/ErrorCode.java
+++ b/moongge/src/main/java/com/narsha/moongge/base/code/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     /**
      * 403 FORBIDDEN
      */
-    STUDENT_NOT_ALLOWED(HttpStatus.FORBIDDEN, "학생은 공지사항은 작성할 수 없습니다."),
+    STUDENT_NOT_ALLOWED_NOTICE(HttpStatus.FORBIDDEN, "학생은 공지사항은 작성할 수 없습니다."),
+    STUDENT_NOT_ALLOWED_GROUP(HttpStatus.FORBIDDEN, "학생은 그룹을 생성할 수 없습니다."),
     GROUP_MISMATCH(HttpStatus.FORBIDDEN, "그룹 코드가 일치하지 않습니다."),
     /*
      * 404 NOT_FOUND: 리소스를 찾을 수 없음

--- a/moongge/src/main/java/com/narsha/moongge/base/dto/group/CreateGroupDTO.java
+++ b/moongge/src/main/java/com/narsha/moongge/base/dto/group/CreateGroupDTO.java
@@ -25,6 +25,6 @@ public class CreateGroupDTO {
     @NotNull(message = "grade을 입력해주세요.")
     private Integer grade;
 
-    @NotNull(message = "group_class을 입력해주세요.")
-    private Integer group_class;
+    @NotNull(message = "groupClass을 입력해주세요.")
+    private Integer groupClass;
 }

--- a/moongge/src/main/java/com/narsha/moongge/base/exception/GlobalExceptionHandler.java
+++ b/moongge/src/main/java/com/narsha/moongge/base/exception/GlobalExceptionHandler.java
@@ -98,6 +98,14 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponseDTO(ErrorCode.DELETE_FAILED_ENTITY_RELATED_GROUPCODE));
     }
 
+    @ExceptionHandler(StudentGroupCreationException.class)
+    protected ResponseEntity<ErrorResponseDTO> handleStudentGroupCreationException(final StudentGroupCreationException e) {
+        log.error("StudentGroupCreationException : {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.STUDENT_NOT_ALLOWED_GROUP.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.STUDENT_NOT_ALLOWED_GROUP));
+    }
+
     /**
      * Comment
      */
@@ -175,8 +183,8 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponseDTO>  handleStudentNoticeCreationException(final StudentNoticeCreationException e) {
         log.error("StudentNoticeCreationException : {}", e.getMessage());
         return ResponseEntity
-                .status(ErrorCode.STUDENT_NOT_ALLOWED.getStatus().value())
-                .body(new ErrorResponseDTO(ErrorCode.STUDENT_NOT_ALLOWED));
+                .status(ErrorCode.STUDENT_NOT_ALLOWED_NOTICE.getStatus().value())
+                .body(new ErrorResponseDTO(ErrorCode.STUDENT_NOT_ALLOWED_NOTICE));
 
     }
 

--- a/moongge/src/main/java/com/narsha/moongge/base/exception/StudentGroupCreationException.java
+++ b/moongge/src/main/java/com/narsha/moongge/base/exception/StudentGroupCreationException.java
@@ -1,0 +1,11 @@
+package com.narsha.moongge.base.exception;
+
+import com.narsha.moongge.base.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StudentGroupCreationException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/moongge/src/main/java/com/narsha/moongge/service/GroupServiceImpl.java
+++ b/moongge/src/main/java/com/narsha/moongge/service/GroupServiceImpl.java
@@ -39,7 +39,7 @@ public class GroupServiceImpl implements GroupService{
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         // 학생 유형 사용자 검증
-        if ("teacher".equals(user.getUserType())) {
+        if ("student".equals(user.getUserType())) {
             throw new StudentGroupCreationException(ErrorCode.STUDENT_NOT_ALLOWED_GROUP);
         }
 

--- a/moongge/src/main/java/com/narsha/moongge/service/GroupServiceImpl.java
+++ b/moongge/src/main/java/com/narsha/moongge/service/GroupServiceImpl.java
@@ -3,8 +3,7 @@ package com.narsha.moongge.service;
 import com.narsha.moongge.base.code.ErrorCode;
 import com.narsha.moongge.base.dto.group.CreateGroupDTO;
 import com.narsha.moongge.base.dto.group.UpdateTimeDTO;
-import com.narsha.moongge.base.exception.GroupNotFoundException;
-import com.narsha.moongge.base.exception.LoginIdNotFoundException;
+import com.narsha.moongge.base.exception.*;
 import com.narsha.moongge.entity.*;
 import com.narsha.moongge.repository.*;
 
@@ -36,6 +35,14 @@ public class GroupServiceImpl implements GroupService{
         // 그룹 생성
         GroupEntity group = buildGroupEntity(createGroupDTO, groupCode);
 
+        UserEntity user = userRepository.findByUserId(createGroupDTO.getUserId())
+                .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // 학생 유형 사용자 검증
+        if ("teacher".equals(user.getUserType())) {
+            throw new StudentGroupCreationException(ErrorCode.STUDENT_NOT_ALLOWED_GROUP);
+        }
+
         // DB에 그룹 생성
         GroupEntity createdGroup  = groupRepository.save(group);
         if (createdGroup  == null || createdGroup .getGroupCode() == null) {
@@ -43,8 +50,6 @@ public class GroupServiceImpl implements GroupService{
         }
 
         // 사용자에 생성된 그룹 업데이트
-        UserEntity user = userRepository.findByUserId(createGroupDTO.getUserId())
-                .orElseThrow(() -> new LoginIdNotFoundException(ErrorCode.USERID_NOT_FOUND));
         user.updateGroup(createdGroup);
 
         // profile badge update
@@ -134,7 +139,7 @@ public class GroupServiceImpl implements GroupService{
                 .school(createGroupDTO.getSchool())
                 .grade(createGroupDTO.getGrade())
                 .groupCode(groupCode)
-                .groupClass(createGroupDTO.getGroup_class())
+                .groupClass(createGroupDTO.getGroupClass())
                 .build();
         return group;
     }

--- a/moongge/src/main/java/com/narsha/moongge/service/NoticeServiceImpl.java
+++ b/moongge/src/main/java/com/narsha/moongge/service/NoticeServiceImpl.java
@@ -42,7 +42,7 @@ public class NoticeServiceImpl implements NoticeService{
 
         // 학생 유형 사용자 검증
         if ("student".equals(user.getUserType())) {
-            throw new StudentNoticeCreationException(ErrorCode.STUDENT_NOT_ALLOWED);
+            throw new StudentNoticeCreationException(ErrorCode.STUDENT_NOT_ALLOWED_NOTICE);
         }
 
         NoticeEntity notice = NoticeEntity.builder()

--- a/moongge/src/test/java/com/narsha/moongge/repository/NoticeRepositoryTest.java
+++ b/moongge/src/test/java/com/narsha/moongge/repository/NoticeRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.narsha.moongge.repository;
 
-import com.narsha.moongge.base.dto.notice.NoticeDTO;
 import com.narsha.moongge.entity.GroupEntity;
 import com.narsha.moongge.entity.NoticeEntity;
 import com.narsha.moongge.entity.UserEntity;
@@ -84,7 +83,7 @@ class NoticeRepositoryTest {
                 .groupName("groupName")
                 .school("school")
                 .grade(3)
-                .group_class(5)
+                .groupClass(5)
                 .userId(user.getUserId())
                 .build();
 

--- a/moongge/src/test/java/com/narsha/moongge/service/GroupServiceImplTest.java
+++ b/moongge/src/test/java/com/narsha/moongge/service/GroupServiceImplTest.java
@@ -49,7 +49,7 @@ class GroupServiceImplTest {
         assertEquals(createGroupDTO.getGroupName(), group.getGroupName(), "그룹 이름이 일치해야 합니다.");
         assertEquals(createGroupDTO.getSchool(), group.getSchool(), "학교 이름이 일치해야 합니다.");
         assertEquals(createGroupDTO.getGrade(), group.getGrade(), "학년이 일치해야 합니다.");
-        assertEquals(createGroupDTO.getGroup_class(), group.getGroupClass(), "반이 일치해야 합니다.");
+        assertEquals(createGroupDTO.getGroupClass(), group.getGroupClass(), "반이 일치해야 합니다.");
     }
 
     @Test
@@ -133,7 +133,7 @@ class GroupServiceImplTest {
                 .groupName("groupName")
                 .school("school")
                 .grade(3)
-                .group_class(5)
+                .groupClass(5)
                 .userId(user.getUserId())
                 .build();
     }

--- a/moongge/src/test/java/com/narsha/moongge/service/NoticeServiceImplTest.java
+++ b/moongge/src/test/java/com/narsha/moongge/service/NoticeServiceImplTest.java
@@ -145,7 +145,7 @@ class NoticeServiceImplTest {
                 .groupName("groupName")
                 .school("school")
                 .grade(3)
-                .group_class(5)
+                .groupClass(5)
                 .userId(user.getUserId())
                 .build();
 

--- a/moongge/src/test/java/com/narsha/moongge/service/UserServiceImplTest.java
+++ b/moongge/src/test/java/com/narsha/moongge/service/UserServiceImplTest.java
@@ -54,7 +54,7 @@ public class UserServiceImplTest {
         createGroupDTO.setGroupName("groupName");
         createGroupDTO.setSchool("school");
         createGroupDTO.setGrade(3);
-        createGroupDTO.setGroup_class(5);
+        createGroupDTO.setGroupClass(5);
         createGroupDTO.setUserId(user.getUserId());
         return createGroupDTO;
     }


### PR DESCRIPTION
## 개요
그룹을 생성 시 선생님이 아닌 학생도 생성이 가능했었음 -> 수정

## 이슈번호
#7 

## 작업사항
- 그룹을 생성할 때 선생님 타입인지 검증 로직 추가
- 학생일 경우 -> 예외 처리

## 추가 및 변경사항
- 학생 신분으로 그룹을 생성 시 필요한 예외 클래스, 예외 코드
