### PR TITLE
🐛 Fix: JPA N+1 문제 수정 및 성능 개선

### DIFF
--- a/moongge/src/main/java/com/narsha/moongge/repository/PostRepository.java
+++ b/moongge/src/main/java/com/narsha/moongge/repository/PostRepository.java
@@ -4,6 +4,8 @@ import com.narsha.moongge.entity.PostEntity;
 import com.narsha.moongge.entity.UserEntity;
 import com.narsha.moongge.entity.GroupEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,4 +18,6 @@ public interface PostRepository extends JpaRepository<PostEntity, Integer> {
     Optional<PostEntity> findByPostIdAndGroup(Integer postId, GroupEntity group);
     Optional<PostEntity> findByPostId(Integer postId);
     List<PostEntity> findByGroupAndCreateAtBetweenOrderByCreateAtDesc(GroupEntity group, LocalDateTime startTime, LocalDateTime endTime);
+    @Query("SELECT p FROM PostEntity p JOIN FETCH p.user JOIN FETCH p.group WHERE p.group = :group AND p.createAt BETWEEN :startTime AND :endTime")
+    List<PostEntity> findPostsWithUserAndGroup(@Param("group") GroupEntity group, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 }

--- a/moongge/src/main/java/com/narsha/moongge/service/PostServiceImpl.java
+++ b/moongge/src/main/java/com/narsha/moongge/service/PostServiceImpl.java
@@ -106,7 +106,7 @@ public class PostServiceImpl implements PostService {
         LocalDateTime endTime = LocalDateTime.now();
         LocalDateTime startTime = LocalDateTime.now().minus(24, ChronoUnit.HOURS);
 
-        List<PostEntity> allPosts = postRepository.findByGroupAndCreateAtBetweenOrderByCreateAtDesc(user.getGroup(), startTime, endTime);
+        List<PostEntity> allPosts = postRepository.findPostsWithUserAndGroup(user.getGroup(), startTime, endTime);
 
         // 유저가 좋아요를 누른 포스트 목록 가져오기
         List<LikeEntity> userLikes = likeRepository.findByUser(user);

--- a/moongge/src/test/java/com/narsha/moongge/repository/PostRepositoryTest.java
+++ b/moongge/src/test/java/com/narsha/moongge/repository/PostRepositoryTest.java
@@ -50,7 +50,7 @@ class PostRepositoryTest {
         LocalDateTime endTime = now.plusDays(1);
 
         // when
-        List<PostEntity> posts = postRepository.findByGroupAndCreateAtBetweenOrderByCreateAtDesc(group, startTime, endTime);
+        List<PostEntity> posts = postRepository.findPostsWithUserAndGroup(group, startTime, endTime);
 
         // then
         assertEquals(3, posts.size(), "조회된 포스트 수가 일치해야 합니다.");


### PR DESCRIPTION
## 개요
JPA의 N+1 쿼리 문제를 수정하고 성능을 개선하기 위한 작업을 포함합니다. `PostServiceImpl`클래스의 `getMainPost`메서드에서 발생하던 N+1 쿼리 문제를 해결하고, 데이터베이스 쿼리를 최적화하여 성능을 향상시켰습니다.

## 이슈 번호
#22 

## 작업사항
- `PostServiceImpl`의 `getMainPost`메서드에서 JOIN FETCH를 사용하여 연관된 `UserEntity`와 `GroupEntity`를 함께 로딩하도록 쿼리를 수정했습니다.
- JPA 쿼리에서 여러 개의 `SELECT`쿼리가 실행되던 문제를 해결하여 성능을 개선했습니다.

## 추가 및 변경사항
- 쿼리 최적화:
    - `PostEntity`와 연관된 `UserEntity`및 `GroupEntity`를 단일 쿼리로 로딩하도록 변경했습니다.
    - 결과적으로 SQL 쿼리의 수가 줄어들어 N+1 쿼리 문제를 해결했습니다.
- 성능 개선:
    - 데이터베이스 쿼리 수가 줄어들어 응답 속도가 개선되었습니다.
    - 불필요한 쿼리 호출을 줄여서 서버의 부하를 감소시켰습니다.
