### PR TITLE
✨Feat: 회원가입 시 불필요한 select 쿼리 나가는 문제 해결

### DIFF
--- a/src/main/java/com/narsha/moongge/entity/UserEntity.java
+++ b/src/main/java/com/narsha/moongge/entity/UserEntity.java
@@ -2,14 +2,16 @@ package com.narsha.moongge.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.domain.Persistable;
 
 
 @Getter
 @Entity
-@Builder // DTO -> Entity
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserEntity {
+public class UserEntity implements Persistable<String> {
+
     @Id
     @Column(nullable = false, length=100)
     @JoinColumn(name = "user_id")
@@ -55,6 +57,10 @@ public class UserEntity {
     @JoinColumn(name = "fcm_token")
     private String fcmToken; // FCM 토큰 필드
 
+    @Transient
+    @Builder.Default
+    private boolean isNew = true;
+
     public void updateBadgeList(String badgeList) {
         this.badgeList = badgeList;
     }
@@ -72,5 +78,21 @@ public class UserEntity {
         this.nickname = nickname;
         this.intro = intro;
         this.profileImage = profileImage;
+    }
+
+    @Override
+    public String getId() {
+        return this.userId;
+    }
+
+    @Override
+    public boolean isNew() {
+        return this.isNew;
+    }
+
+    @PostLoad
+    @PrePersist
+    private void markNotNew() {
+        this.isNew = false;
     }
 }


### PR DESCRIPTION
## 개요
1차 USER - 쿼리 최적화

- 회원가입
`save()` 메서드 호출 시 발생하는 불필요한 `SELECT` 쿼리를 방지하기 위해 엔티티를 수정

## 이슈 번호
#27 

## 작업사항
- `Persistable` 인터페이스를 구현하여 엔티티 클래스에 `isNew` 필드를 추가
- `isNew` 필드를 통해 엔티티가 새로운 상태인지 여부를 효율적으로 확인할 수 있도록 함
- `@PostLoad`와 `@PrePersist` 애너테이션을 사용하여 `isNew` 필드의 값을 적절히 관리하도록 설정
- 엔티티의 `@Id` 필드가 자동 생성이 아닌 생성자를 통해 입력되기 때문에, `save()` 호출 시 발생하는 불필요한 `SELECT` 쿼리를 줄이기 위한 조치를 취함

## 추가 및 변경사항
- `UserEntity` 클래스에 `Persistable` 인터페이스를 구현하고 `isNew` 메서드를 추가
- `@Transient` 애너테이션을 사용하여 `isNew` 필드를 데이터베이스와의 매핑에서 제외
- `@PostLoad`와 `@PrePersist` 메서드를 활용하여 엔티티 로딩 및 저장 시 `isNew` 필드를 적절히 업데이트 하도록 함
- 이로 인해 엔티티의 상태를 더 효율적으로 관리할 수 있게 되었으며, `save()` 호출 시 불필요한 데이터베이스 조회를 줄임
참고 블로그: https://pyounani.tistory.com/23 
