### PR TITLE
🐛 Fix:  REST API에 맞게 경로 수정

### DIFF
--- a/src/main/java/com/narsha/moongge/controller/NoticeController.java
+++ b/src/main/java/com/narsha/moongge/controller/NoticeController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notices")
+@RequestMapping("/api")
 @Tag(name = "NoticeController", description = "공지 관련 API")
 public class NoticeController {
 
@@ -27,7 +27,7 @@ public class NoticeController {
     /**
      * 공지 작성하기 API
      */
-    @PostMapping
+    @PostMapping("/users/{userId}/notices")
     @Operation(
             summary = "공지 작성",
             description = "주어진 그룹 코드에 대해 새로운 공지를 작성하는 API",
@@ -43,8 +43,9 @@ public class NoticeController {
                     @ApiResponse(responseCode = "403", description = "학생은 그룹을 생성할 수 없습니다.", content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json"))
             }
     )
-    public ResponseEntity<ResponseDTO> createNotice(@Valid @RequestBody CreateNoticeDTO createNoticeDTO) {
-        NoticeDTO res = noticeService.createNotice(createNoticeDTO);
+    public ResponseEntity<ResponseDTO> createNotice(@PathVariable String userId,
+                                                    @Valid @RequestBody CreateNoticeDTO createNoticeDTO) {
+        NoticeDTO res = noticeService.createNotice(userId, createNoticeDTO);
 
         return ResponseEntity
                 .status(ResponseCode.SUCCESS_CREATE_NOTICE.getStatus().value())
@@ -54,7 +55,7 @@ public class NoticeController {
     /**
      * 공지 목록 불러오기 API
      */
-    @GetMapping("/{userId}")
+    @GetMapping("/users/{userId}/notices")
     @Operation(
             summary = "공지 목록 조회",
             description = "주어진 그룹 코드에 대해 공지 목록을 조회하는 API",
@@ -76,7 +77,7 @@ public class NoticeController {
     /**
      * 공지 상세사항 내용 불러오기 API
      */
-    @GetMapping("/{userId}/{noticeId}")
+    @GetMapping("/users/{userId}/notices/{noticeId}")
     @Operation(
             summary = "공지 상세 조회",
             description = "주어진 그룹 코드와 공지 ID에 대해 공지의 상세 내용을 조회하는 API",
@@ -103,7 +104,7 @@ public class NoticeController {
     /**
      * 최근에 올린 공지 한 개 API
      */
-    @GetMapping("/{userId}/recent")
+    @GetMapping("/users/{userId}/notices/recent")
     @Operation(
             summary = "최근 공지 조회",
             description = "주어진 그룹 코드에 대해 최근에 올라온 공지 하나를 조회하는 API",

--- a/src/main/java/com/narsha/moongge/service/NoticeService.java
+++ b/src/main/java/com/narsha/moongge/service/NoticeService.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface NoticeService {
 
-    NoticeDTO createNotice(CreateNoticeDTO createNoticeDTO);
+    NoticeDTO createNotice(String userId, CreateNoticeDTO createNoticeDTO);
     List<NoticeDTO> getNoticeList(String userId);
     NoticeDTO getNoticeDetail(String userId, Integer noticeId);
     NoticeDTO getRecentNoticeOne(String userId);

--- a/src/main/java/com/narsha/moongge/service/NoticeServiceImpl.java
+++ b/src/main/java/com/narsha/moongge/service/NoticeServiceImpl.java
@@ -30,9 +30,9 @@ public class NoticeServiceImpl implements NoticeService{
      */
     @Override
     @Transactional
-    public NoticeDTO createNotice(CreateNoticeDTO createNoticeDTO) {
+    public NoticeDTO createNotice(String userId, CreateNoticeDTO createNoticeDTO) {
 
-        UserEntity findUser = userRepository.findUserWithGroup(createNoticeDTO.getWriter())
+        UserEntity findUser = userRepository.findUserWithGroup(userId)
                 .orElseThrow(() -> new UserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
         // 선생님 유형 사용자 검증

--- a/src/test/java/com/narsha/moongge/service/NoticeServiceImplTest.java
+++ b/src/test/java/com/narsha/moongge/service/NoticeServiceImplTest.java
@@ -41,7 +41,7 @@ class NoticeServiceImplTest {
         CreateNoticeDTO createNoticeDTO = buildCreateNoticeDTO(user);
 
         // when
-        NoticeDTO noticeDTO = noticeService.createNotice(createNoticeDTO);
+        NoticeDTO noticeDTO = noticeService.createNotice(user.getUserId(), createNoticeDTO);
 
         // then
         Optional<NoticeEntity> savedNotice = noticeRepository.findByNoticeId(noticeDTO.getNoticeId());
@@ -63,7 +63,7 @@ class NoticeServiceImplTest {
         GroupEntity group = createGroup(user);
         CreateNoticeDTO createNoticeDTO = buildCreateNoticeDTO(user);
 
-        NoticeDTO noticeDTO = noticeService.createNotice(createNoticeDTO);
+        NoticeDTO noticeDTO = noticeService.createNotice(user.getUserId(), createNoticeDTO);
 
         // when
         List<NoticeDTO> noticeList = noticeService.getNoticeList(user.getUserId());
@@ -86,10 +86,10 @@ class NoticeServiceImplTest {
         UserEntity user = createUser();
         GroupEntity group = createGroup(user);
         CreateNoticeDTO createNoticeDTO1 = buildCreateNoticeDTO(user);
-        noticeService.createNotice(createNoticeDTO1);
+        noticeService.createNotice(user.getUserId(), createNoticeDTO1);
 
         CreateNoticeDTO createNoticeDTO2 = buildCreateNoticeDTO(user);
-        NoticeDTO recentNoticeDTO = noticeService.createNotice(createNoticeDTO2);
+        NoticeDTO recentNoticeDTO = noticeService.createNotice(user.getUserId(), createNoticeDTO2);
 
         // when
         NoticeDTO noticeDTO = noticeService.getRecentNoticeOne(user.getUserId());
@@ -112,7 +112,7 @@ class NoticeServiceImplTest {
         UserEntity user = createUser();
         GroupEntity group = createGroup(user);
         CreateNoticeDTO createNoticeDTO = buildCreateNoticeDTO(user);
-        NoticeDTO noticeDTO = noticeService.createNotice(createNoticeDTO);
+        NoticeDTO noticeDTO = noticeService.createNotice(user.getUserId(), createNoticeDTO);
 
         // when
         NoticeDTO findNoticeDTO = noticeService.getNoticeDetail(user.getUserId(), noticeDTO.getNoticeId());


### PR DESCRIPTION
## 개요
REST API에 맞지 않게 경로가 설계되어있음
-> 프론트가 이해하기 쉽게 경로 수정 

## 이슈번호
#35 

## 작업사항
- user에 대한 리소스가 먼저 > 공지에 대한 리소스
- ex. `/notices/{userId}` > `/users/{userId}/notices`

## 추가 및 변경사항
- API 스펙 수정
